### PR TITLE
NavBar Cart Counter Update

### DIFF
--- a/client/components/AllFlowers.js
+++ b/client/components/AllFlowers.js
@@ -10,6 +10,9 @@ import { addItem } from '../store/cart';
 export class AllFlowers extends React.Component {
     constructor() {
         super();
+        if (!ls.get('cart')) {
+            ls.set('cart', {cart: [], qty: 0});
+        }
         this.handleAddToCart = this.handleAddToCart.bind(this);
     }
     async componentDidMount() {
@@ -21,29 +24,30 @@ export class AllFlowers extends React.Component {
         const currentUser = await this.props.fetchMe();
         const userType = currentUser ? 'member' : 'guest';
         if (userType === 'guest') {
-            let getCart = ls.get('cart');
+            let local = ls.get('cart');
             let itemToAdd = {
                 plantId: this.props.targetFlower.id,
                 price: this.props.targetFlower.price,
                 quantity: 1,
             };
-            if (getCart.length < 1) {
-                getCart = [itemToAdd, ...getCart]
+            if (local.cart.length < 1) {
+                local.cart = [itemToAdd, ...local.cart]
             } else {
                 let count = 0;
-                for (let i = 0; i < getCart.length; i++) {
-                    if (itemToAdd.plantId === getCart[i].plantId) {
-                        let updatedItem = getCart.splice(i, 1)
+                for (let i = 0; i < local.cart.length; i++) {
+                    if (itemToAdd.plantId === local.cart[i].plantId) {
+                        let updatedItem = local.cart.splice(i, 1)
                         updatedItem[0].quantity++
-                        getCart = [updatedItem[0], ...getCart]
+                        local.cart = [updatedItem[0], ...local.cart]
                         count++;
                     }
                 }
                 if (count === 0) {
-                    getCart = [itemToAdd, ...getCart]
+                    local.cart = [itemToAdd, ...local.cart]
                 }
             }
-            ls.set('cart', getCart);
+            local.qty++
+            ls.set('cart', local);
         }
         else {
             await this.props.addItemToCart(this.props.userId, targetId, 1);

--- a/client/components/Navbar.js
+++ b/client/components/Navbar.js
@@ -35,7 +35,6 @@ export class Navbar extends React.Component {
   }
 
   async componentDidUpdate() {
-    console.log('UPDATING')
     if (this.state.qty !== this.props.cart.qty) {
       const currentUser = await this.props.fetchMe();
       const userType = currentUser ? 'member' : 'guest';

--- a/client/components/Navbar.js
+++ b/client/components/Navbar.js
@@ -97,7 +97,9 @@ export class Navbar extends React.Component {
 
           <div className='CartButtonContainer'>
             <Link to="/cart"><div className='CartButton'></div></Link>
-            <div className='CartCounter'>{this.state.qty}</div>
+            {!this.state.qty < 1 ? (
+              <div className='CartCounter'>{this.state.qty}</div>
+            ) : (<div/>)}
           </div>
         </nav>
         <hr />

--- a/client/components/Navbar.js
+++ b/client/components/Navbar.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useState } from 'react'
 import { connect } from 'react-redux'
 import { Link } from 'react-router-dom'
 import { logout } from '../store'
@@ -7,36 +7,65 @@ import { fetchCart } from '../store/cart';
 import ls from 'local-storage';
 
 export class Navbar extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       userType: '',
-      qty: 0
+      cart: this.userType === 'member' ? this.props.cart.cart : ls.get('cart'),
+      qty: this.props.cart.qty
     }
   }
 
   async componentDidMount() {
     const currentUser = await this.props.fetchMe();
     const userType = currentUser ? 'member' : 'guest';
-    let cart = [];
-    if (userType === 'guest') {
-      cart = ls.get('cart');
-    } else if (userType === 'member') {
-      await this.props.fetchCart(this.props.userId);
-      cart = this.props.cart;
-    }
+    // let cart = this.state.cart;
+    // if (userType === 'guest') {
+    //   cart = ls.get('cart');
+    // } else if (userType === 'member') {
+    //   // await this.props.fetchCart(this.props.userId);
+    //   cart = this.props.cart;
+    // }
 
-    let qty = 0;
-    for (let item in cart) {
-      qty += cart[item].quantity;
-    }
+    // let qty = 0;
+    // for (let item in cart) {
+    //   qty += cart[item].quantity;
+    // }
     this.setState({
       userType,
-      qty
+      qty: this.props.cart.qty
     });
   }
 
+  // async componentDidUpdate() {
+  //   const currentUser = await this.props.fetchMe();
+  //   const userType = currentUser ? 'member' : 'guest';
+  //   let cart = [];
+  //   if (userType === 'guest') {
+  //     cart = ls.get('cart');
+  //   } else if (userType === 'member') {
+  //     // await this.props.fetchCart(this.props.userId);
+  //     cart = this.props.cart;
+  //   }
+
+  //   let qty = 0;
+  //   for (let item in cart) {
+  //     qty += cart[item].quantity;
+  //   }
+
+  //   console.log('UPDATING')
+  //   if(this.state.qty !== qty) {
+  //     this.setState({
+  //       userType,
+  //       cart,
+  //       qty
+  //     });
+  //   }
+    
+  // }
+
   render() {
+    console.log(this.props.cart)
     return (
       <div className='NavBarContainer'>
         <div className='Logo'></div>
@@ -73,7 +102,7 @@ export class Navbar extends React.Component {
 
           <div className='CartButtonContainer'>
             <Link to="/cart"><div className='CartButton'></div></Link>
-            <div className='CartCounter'>{this.state.qty}</div>
+            <div className='CartCounter'>{this.props.cart.qty}</div>
           </div>
         </nav>
         <hr />

--- a/client/components/Navbar.js
+++ b/client/components/Navbar.js
@@ -9,63 +9,59 @@ import ls from 'local-storage';
 export class Navbar extends React.Component {
   constructor(props) {
     super(props);
+    this.handleClick = this.handleClick.bind(this)
     this.state = {
       userType: '',
-      cart: this.userType === 'member' ? this.props.cart.cart : ls.get('cart'),
-      qty: this.props.cart.qty
+      qty: this.userType === 'member' ? this.props.cart.qty : ls.get('cart').qty
     }
   }
 
   async componentDidMount() {
     const currentUser = await this.props.fetchMe();
     const userType = currentUser ? 'member' : 'guest';
-    // let cart = this.state.cart;
-    // if (userType === 'guest') {
-    //   cart = ls.get('cart');
-    // } else if (userType === 'member') {
-    //   // await this.props.fetchCart(this.props.userId);
-    //   cart = this.props.cart;
-    // }
+    await this.props.fetchCart(this.props.userId);
 
-    // let qty = 0;
-    // for (let item in cart) {
-    //   qty += cart[item].quantity;
-    // }
+    let qty = 0
+    if (userType === 'guest') {
+      qty = ls.get('cart').qty;
+    } else if (userType === 'member') {
+      qty = this.props.cart.qty
+    }
+
     this.setState({
       userType,
-      qty: this.props.cart.qty
+      qty
     });
   }
 
-  // async componentDidUpdate() {
-  //   const currentUser = await this.props.fetchMe();
-  //   const userType = currentUser ? 'member' : 'guest';
-  //   let cart = [];
-  //   if (userType === 'guest') {
-  //     cart = ls.get('cart');
-  //   } else if (userType === 'member') {
-  //     // await this.props.fetchCart(this.props.userId);
-  //     cart = this.props.cart;
-  //   }
+  async componentDidUpdate() {
+    console.log('UPDATING')
+    if (this.state.qty !== this.props.cart.qty) {
+      const currentUser = await this.props.fetchMe();
+      const userType = currentUser ? 'member' : 'guest';
+      await this.props.fetchCart(this.props.userId);
 
-  //   let qty = 0;
-  //   for (let item in cart) {
-  //     qty += cart[item].quantity;
-  //   }
+      let qty = 0
+      if (userType === 'guest') {
+        qty = ls.get('cart').qty
+      } else if (userType === 'member') {
+        qty = this.props.cart.qty
+      }
 
-  //   console.log('UPDATING')
-  //   if(this.state.qty !== qty) {
-  //     this.setState({
-  //       userType,
-  //       cart,
-  //       qty
-  //     });
-  //   }
-    
-  // }
+      this.setState({
+        userType,
+        qty
+      });
+    }
+  }
+
+  handleClick() {
+    const qty = ls.get('cart').qty
+    this.setState({userType: 'guest', qty})
+    this.props.logout()
+  }
 
   render() {
-    console.log(this.props.cart)
     return (
       <div className='NavBarContainer'>
         <div className='Logo'></div>
@@ -78,7 +74,7 @@ export class Navbar extends React.Component {
                 {/* The navbar will show these links after you log in */}
                 <Link to="/home">Home</Link>
                 <Link to="/users">View Users</Link>
-                <a href="#" onClick={this.props.handleClick}>
+                <a href="#" onClick={this.handleClick}>
                   Logout
                 </a>
               </div>
@@ -86,7 +82,7 @@ export class Navbar extends React.Component {
               <div className='LoginOut'>
                 {/* The navbar will show these links after you log in */}
                 <Link to="/home">Home</Link>
-                <a href="#" onClick={this.props.handleClick}>
+                <a href="#" onClick={this.handleClick}>
                   Logout
                 </a>
               </div>
@@ -102,7 +98,7 @@ export class Navbar extends React.Component {
 
           <div className='CartButtonContainer'>
             <Link to="/cart"><div className='CartButton'></div></Link>
-            <div className='CartCounter'>{this.props.cart.qty}</div>
+            <div className='CartCounter'>{this.state.qty}</div>
           </div>
         </nav>
         <hr />
@@ -120,15 +116,13 @@ const mapState = state => {
     isLoggedIn: !!state.auth.id,
     isAdmin: state.auth.isAdmin,
     cart: state.cartReducer,
-    userId: state.auth.id
+    userId: state.auth.id,
   }
 }
 
 const mapDispatch = dispatch => {
   return {
-    handleClick() {
-      dispatch(logout())
-    },
+    logout: () => dispatch(logout()),
     fetchCart: (id) => dispatch(fetchCart(id)),
     fetchMe: () => dispatch(me())
   }

--- a/client/components/SingleFlower.js
+++ b/client/components/SingleFlower.js
@@ -9,9 +9,6 @@ import { addItem } from '../store/cart';
 export class SingleFlower extends React.Component {
   constructor() {
     super();
-    if (!ls.get('cart')) {
-      ls.set('cart', []);
-    }
     this.handleAddToCart = this.handleAddToCart.bind(this);
     this.handleChange = this.handleChange.bind(this);
     this.state = {
@@ -39,29 +36,30 @@ export class SingleFlower extends React.Component {
     const currentUser = await this.props.fetchMe();
     const userType = currentUser ? 'member' : 'guest';
     if (userType === 'guest') {
-      let getCart = ls.get('cart');
+      let local = ls.get('cart');
       let itemToAdd = {
         plantId: this.props.targetFlower.id,
         price: this.props.targetFlower.price,
         quantity: this.state.qty,
       };
-      if (getCart.length < 1) {
-        getCart = [itemToAdd, ...getCart]
+      if (local.cart.length < 1) {
+        local.cart = [itemToAdd, ...local.cart]
       } else {
         let count = 0;
-        for (let i = 0; i < getCart.length; i++) {
-          if (itemToAdd.plantId === getCart[i].plantId) {
-            let updatedItem = getCart.splice(i, 1)
+        for (let i = 0; i < local.cart.length; i++) {
+          if (itemToAdd.plantId === local.cart[i].plantId) {
+            let updatedItem = local.cart.splice(i, 1)
             updatedItem[0].quantity += this.state.qty;
-            getCart = [updatedItem[0], ...getCart]
+            local.cart = [updatedItem[0], ...local.cart];
+            local.qty += this.state.qty;
             count++;
           }
         }
         if (count === 0) {
-          getCart = [itemToAdd, ...getCart]
+          local.cart = [itemToAdd, ...local.cart]
         }
       }
-      ls.set('cart', getCart);
+      ls.set('cart', local);
     } else {
       await this.props.addItemToCart(this.props.userId, parseInt(this.props.match.params.flowersId), parseInt(this.state.qty));
     }

--- a/client/components/cartView.js
+++ b/client/components/cartView.js
@@ -25,7 +25,7 @@ export class CartView extends React.Component {
             cart = ls.get('cart');
         } else if (userType === 'member') {
             await this.props.fetchCart(this.props.userId);
-            cart = this.props.cart;
+            cart = this.props.cart.cart;
         }
 
         this.setState({
@@ -48,7 +48,7 @@ export class CartView extends React.Component {
             await this.props.removeFromCart(this.props.userId, event.target.name);
             await this.props.fetchCart(this.props.userId)
             this.setState({
-                cart: this.props.cart
+                cart: this.props.cart.cart
             })
         }
     }
@@ -68,7 +68,7 @@ export class CartView extends React.Component {
             await this.props.fetchCart(this.props.userId)
             this.setState({
                 userType: this.state.userType,
-                cart: this.props.cart
+                cart: this.props.cart.cart
             })
         }
     }

--- a/client/components/cartView.js
+++ b/client/components/cartView.js
@@ -22,7 +22,7 @@ export class CartView extends React.Component {
         const userType = currentUser ? 'member' : 'guest';
         let cart = [];
         if (userType === 'guest') {
-            cart = ls.get('cart');
+            cart = ls.get('cart').cart;
         } else if (userType === 'member') {
             await this.props.fetchCart(this.props.userId);
             cart = this.props.cart.cart;
@@ -39,7 +39,11 @@ export class CartView extends React.Component {
             // Handle remove from local storage here
             let cart = this.state.cart;
             cart = [...cart.filter(item => item.plantId != event.target.name)]
-            ls.set('cart', cart)
+            let qty = 0
+            for(let i in cart) {
+                qty += cart[i].quantity
+            }
+            ls.set('cart', {cart, qty})
             this.setState({
                 userType: this.state.userType,
                 cart
@@ -58,7 +62,11 @@ export class CartView extends React.Component {
         const plantId = event.target.name;
         if(this.state.userType == 'guest'){
             const cart = [...this.state.cart.map(item => item.plantId != plantId ? item : { ...item, quantity: newQty })]
-            ls.set('cart', cart)
+            let qty = 0
+            for(let i in cart) {
+                qty += cart[i].quantity
+            }
+            ls.set('cart', {cart, qty})
             this.setState({
                 userType: this.state.userType,
                 cart

--- a/client/store/cart.js
+++ b/client/store/cart.js
@@ -28,47 +28,58 @@ export const fetchCart = (userId) => {
 export const addItem = (userId, plantId, qty) => {
   return async (dispatch) => {
     const token = window.localStorage.getItem('token');
-      const { data: addedItem } = await Axios.post(`/api/users/${userId}/current-order/${plantId}`, {plantId, qty}, {
-        headers: {
-          authorization: token
-        }
-      })
-      dispatch(_addItem(addedItem))
+    const { data: addedItem } = await Axios.post(`/api/users/${userId}/current-order/${plantId}`, { plantId, qty }, {
+      headers: {
+        authorization: token
+      }
+    })
+    dispatch(_addItem(addedItem))
   }
 }
 
 export const removeItem = (userId, plantId) => {
   return async (dispatch) => {
     const token = window.localStorage.getItem('token');
-      const { data: removedItem } = await Axios.delete(`/api/users/${userId}/current-order/${plantId}`,{
-        plantId,
-        headers:{
-          authorization: token
-        }
-      })
-      dispatch(_removeItem(removedItem))
+    const { data: removedItem } = await Axios.delete(`/api/users/${userId}/current-order/${plantId}`, {
+      plantId,
+      headers: {
+        authorization: token
+      }
+    })
+    dispatch(_removeItem(removedItem))
   }
 }
 
 export const updateQty = (userId, plantId, newQty) => {
   return async (dispatch) => {
     const token = window.localStorage.getItem('token');
-      const { data: updatedItem } = await Axios.put(`/api/users/${userId}/current-order/${plantId}`, {newQty}, {
-        headers: {
-          authorization: token
-        }
-      })
-      dispatch(_updateQty(updatedItem))
+    const { data: updatedItem } = await Axios.put(`/api/users/${userId}/current-order/${plantId}`, { newQty }, {
+      headers: {
+        authorization: token
+      }
+    })
+    dispatch(_updateQty(updatedItem))
   }
 }
 
 //////Reducer
-export default function (state = [], action) {
+export default function (state = {cart: [], qty: 0}, action) {
   switch (action.type) {
     case SET_CART:
-      return action.cart;
-    case ADD_ITEM:
-      return [action.item, ...state]
+      let qty = 0;
+      for (let item in action.cart) {
+        qty += action.cart[item].quantity;
+      }
+      return { cart: action.cart, qty };
+    case ADD_ITEM: 
+    {
+      let cart = [action.item, ...state.cart];
+      let qty = 0;
+      for (let item in cart) {
+        qty += cart[item].quantity;
+      }
+      return {cart, qty}
+    } 
     case REMOVE_ITEM:
       return [...state.filter(item => item.id !== action.item.id)]
     default:

--- a/client/store/cart.js
+++ b/client/store/cart.js
@@ -63,25 +63,43 @@ export const updateQty = (userId, plantId, newQty) => {
 }
 
 //////Reducer
-export default function (state = {cart: [], qty: 0}, action) {
+export default function (state = { cart: [], qty: 0 }, action) {
   switch (action.type) {
     case SET_CART:
-      let qty = 0;
-      for (let item in action.cart) {
-        qty += action.cart[item].quantity;
+      {
+        let qty = 0;
+        for (let item in action.cart) {
+          qty += action.cart[item].quantity;
+        }
+        return { cart: action.cart, qty };
       }
-      return { cart: action.cart, qty };
-    case ADD_ITEM: 
-    {
-      let cart = [action.item, ...state.cart];
-      let qty = 0;
-      for (let item in cart) {
-        qty += cart[item].quantity;
+    case ADD_ITEM:
+      {
+        let cart = [action.item, ...state.cart];
+        let qty = 0;
+        for (let item in cart) {
+          qty += cart[item].quantity;
+        }
+        return { cart, qty }
       }
-      return {cart, qty}
-    } 
     case REMOVE_ITEM:
-      return [...state.filter(item => item.id !== action.item.id)]
+      {
+        let cart = [...state.cart.filter(item => item.id !== action.item.id)];
+        let qty = 0;
+        for (let item in cart) {
+          qty += cart[item].quantity;
+        }
+        return { cart, qty }
+      }
+    case UPDATE_QTY:
+      {
+        let cart = [...state.cart.map(item => item.id === action.item.id ? action.item : item)]
+        let qty = 0;
+        for (let item in cart) {
+          qty += cart[item].quantity;
+        }
+        return { cart, qty }
+      }
     default:
       return state;
   }


### PR DESCRIPTION
The cart counter on the navbar now updates in real-time to correctly display the number of items in a users cart as they add items or change quantity of items. If the users cart is empty, the cart counter is not rendered.
Only works with logged-in users.

For guests, the nav bar cart counter only displays correct info after a page refresh. Local storage is not connected to state so the page will not refresh on change. (Still working on this issue)
